### PR TITLE
Versioning

### DIFF
--- a/custom_components/cometblue/manifest.json
+++ b/custom_components/cometblue/manifest.json
@@ -5,4 +5,5 @@
   "dependencies": [],
   "codeowners": ["@neffs"],
   "requirements": ["cometblue_lite==0.3.2"]
+  "version": "0.0.3"
 }


### PR DESCRIPTION
A quick dirty workaround, since Home Assistant now ask for a "version". It needs to be some kind of number.