### PR TITLE
Fix manifest.json syntax

### DIFF
--- a/custom_components/cometblue/manifest.json
+++ b/custom_components/cometblue/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://github.com/neffs/ha-cometblue",
   "dependencies": [],
   "codeowners": ["@neffs"],
-  "requirements": ["cometblue_lite==0.3.2"]
+  "requirements": ["cometblue_lite==0.3.2"],
   "version": "0.0.3"
 }


### PR DESCRIPTION
Fixing a typo in manifest.json that produces the following error:
`ERROR (MainThread) [custom_components.hacs] <Integration neffs/ha-cometblue> Could not read manifest.json [Expecting ',' delimiter: line 8 column 3 (char 206)]`