### PR TITLE
Add HVAC_MODE_OFF and offset_temperature 

### DIFF
--- a/custom_components/cometblue/climate.py
+++ b/custom_components/cometblue/climate.py
@@ -35,6 +35,7 @@ from homeassistant.const import (
     TEMP_CELSIUS,
     ATTR_TEMPERATURE,
     ATTR_BATTERY_LEVEL,
+    ATTR_LOCKED,
     PRECISION_HALVES)
 
 import homeassistant.helpers.config_validation as cv
@@ -44,7 +45,10 @@ _LOGGER.setLevel(10)
 
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=300)
 
+ATTR_BATTERY_LOW = 'battery_low'
 ATTR_OFFSET = 'offset'
+ATTR_STATUS = 'status'
+ATTR_WINDOW_OPEN = 'window_open'
 
 DEVICE_SCHEMA = vol.Schema({
     vol.Required(CONF_MAC): cv.string,
@@ -165,10 +169,14 @@ class CometBlueThermostat(ClimateEntity):
         """Return the device specific state attributes."""
         return {
             ATTR_BATTERY_LEVEL: self._thermostat.battery_level,
+            ATTR_BATTERY_LOW: self._thermostat.low_battery,
+            ATTR_LOCKED: self._thermostat.locked,
+            ATTR_OFFSET: self._thermostat.offset_temperature,
+            ATTR_STATUS: self._thermostat.status,
+            ATTR_WINDOW_OPEN: self._thermostat.window_open,
             "model_type": self._thermostat.firmware_rev,
             "target_high": self._thermostat.target_temperature_high,
             "target_low": self._thermostat.target_temperature_low,
-            ATTR_OFFSET: self._thermostat.offset_temperature,
         }
 
     def update(self):

--- a/custom_components/cometblue/climate.py
+++ b/custom_components/cometblue/climate.py
@@ -26,6 +26,7 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_HEAT,
     HVAC_MODE_AUTO,
     SUPPORT_TARGET_TEMPERATURE,
+    DOMAIN,
 )
 from homeassistant.const import (
     CONF_NAME,
@@ -94,6 +95,20 @@ class CometBlueThermostat(ClimateEntity):
     def available(self) -> bool:
         """Return if thermostat is available."""
         return self._thermostat.available
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        versions = [self._thermostat.firmware_rev, self._thermostat.software_rev]
+        device_info = {
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "name": self.name,
+            "manufacturer": self._thermostat.manufacturer,
+            "model": self._thermostat.model,
+            "sw_version": ", ".join([rev for rev in versions if rev]),
+        }
+
+        return {k: v for k, v in device_info.items() if v}
 
     @property
     def supported_features(self):

--- a/custom_components/cometblue/manifest.json
+++ b/custom_components/cometblue/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://github.com/neffs/ha-cometblue",
   "dependencies": [],
   "codeowners": ["@neffs"],
-  "requirements": ["cometblue_lite==0.3.2"],
-  "version": "0.0.3"
+  "requirements": ["cometblue_lite==0.4.0"],
+  "version": "0.0.4"
 }

--- a/custom_components/cometblue/manifest.json
+++ b/custom_components/cometblue/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://github.com/neffs/ha-cometblue",
   "dependencies": [],
   "codeowners": ["@neffs"],
-  "requirements": ["cometblue_lite==0.4.0"],
+  "requirements": ["cometblue_lite==0.4.1"],
   "version": "0.0.4"
 }


### PR DESCRIPTION
This PR adds the possibility to turn the thermostat off. 
A temperature below 7°C is interpreted as "off" by the device, 
this code adds function `HVAC_MODE_OFF` for that.
I've been using it ever since, successfully. The set temperature is restored when
the device is turned on again.

I also added support for `offset_temperature`.